### PR TITLE
chore: specify output tracing root

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,10 @@
+const path = require('path');
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    outputFileTracingRoot: path.join(__dirname),
+  },
+};
+
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- specify outputFileTracingRoot in next.js config to avoid extraneous package-lock warnings

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1854c996c8330a6eb080f72db4078